### PR TITLE
Expose the right "dist" URL containing the JS content

### DIFF
--- a/Swift/Sources/DittoPresenceViewerCore/DittoPresenceViewerCore.swift
+++ b/Swift/Sources/DittoPresenceViewerCore/DittoPresenceViewerCore.swift
@@ -8,6 +8,6 @@ import Foundation
 
 public struct DittoPresenceViewerResources {
     // These public accessors let consuming packages (e.g. DittoSwiftTools) use the bundled resources (JS & HTML) from this package
-    public static let webDistDirURL = Bundle.module.bundleURL.appendingPathComponent("dist")
     public static let htmlURL = Bundle.module.url(forResource: "index", withExtension: "html")!
+    public static let webDistDirURL = htmlURL.deletingLastPathComponent()
 }


### PR DESCRIPTION
Fixes the URL for the JS content as used by WebKit when rednering the presence viewer on macOS